### PR TITLE
Add security headers in Django settings file

### DIFF
--- a/zygoat/components/backend/settings/__init__.py
+++ b/zygoat/components/backend/settings/__init__.py
@@ -12,6 +12,7 @@ from .cookies import cookies
 from .drf_camelize import drf_camelize
 from .reverse_proxy import reverse_proxy
 from .env import env
+from .security import security
 
 log = logging.getLogger()
 
@@ -53,6 +54,7 @@ settings_sub_components = [
     installed_apps,
     allowed_hosts,
     cookies,
+    security,
     drf_camelize,
     reverse_proxy,
     env,

--- a/zygoat/components/backend/settings/security.py
+++ b/zygoat/components/backend/settings/security.py
@@ -1,0 +1,33 @@
+import logging
+
+from zygoat.components import SettingsComponent
+
+log = logging.getLogger()
+
+security_headers = """\
+if not DEBUG:
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+"""
+
+
+class Security(SettingsComponent):
+    def create(self):
+        red = self.parse()
+
+        log.info("Adding security headers")
+
+        red.extend(
+            ["\n", "# Set security headers", "\n", security_headers,]
+        )
+        self.dump(red)
+
+    @property
+    def installed(self):
+        red = self.parse()
+        return red.find("name", value="SECURE_HSTS_SECONDS") is not None
+
+
+security = Security()


### PR DESCRIPTION
From https://github.com/bequest/willing-app/pull/2132

Since these are all new apps, I figured I would set the `HSTS` browser remember time to 1 year which is what is recommended.

I am not sure if there is a better way to find if all the value changes in a RedBaron node can be captured in the `update` phase. The check here in `installed` simply looks for one value and nothing more, I see the other sub components are also done this way? So if there is a value change or a new config in the already installed sub-component, we would miss updating it with just `zg update`. I had to delete and update.