### PR TITLE
Add frontend utility folder

### DIFF
--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -1,3 +1,5 @@
+import os
+
 from importlib_metadata import version
 
 from box import Box
@@ -18,5 +20,7 @@ project_dir_names = [
 
 Phases = Box([(t.upper(), t) for t in phase_function_names])
 Projects = Box([(t.upper(), t) for t in project_dir_names])
+
+FrontendUtils = os.path.join(Projects.FRONTEND, "zg_utils")
 
 __version__ = version("zygoat")


### PR DESCRIPTION
We should be adding more utility files for use with our repos (like https://github.com/MetLifeLegalPlans/willing-zg/pull/1) and it'll be good to define a central file for those utility files. Thanks Ian for the suggestion. Happy to change names/whatever to what people think is best.

Tested with the plugin changes, working.