### PR TITLE
Rotate image plugin order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "0.6.0"
+version = "0.6.1"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/frontend/resources/zygoat.next.config.js
+++ b/zygoat/components/frontend/resources/zygoat.next.config.js
@@ -19,6 +19,6 @@ const config = {
   },
 };
 
-const plugins = [withImages, withSvgr];
+const plugins = [withSvgr, withImages];
 
 module.exports = { plugins, config };


### PR DESCRIPTION
This will (hopefully) fix SVG handling so that it is matched by webpack first.