### PR TITLE
Properly echo update events down the tree

### DIFF
--- a/zygoat/components/base.py
+++ b/zygoat/components/base.py
@@ -111,7 +111,7 @@ class Component:
 
         self.reload()
 
-        if phase == Phases.UPDATE and not self.installed:
+        if phase == Phases.UPDATE and self.installed is False:
             log.info(
                 "Update phase called for a non-installed component, running the create phase instead"
             )
@@ -165,7 +165,7 @@ class Component:
         """
         Halts the create phase if True
         """
-        return False
+        return None
 
     def list(self):
         """


### PR DESCRIPTION
Currently we use an empty shell component to group related sub components together. That's a good pattern and I like, but `installed` actually has 3 states - installed, not installed, and irrelevant. We want `irrelevant` to just propagate the `update` event down the tree so file components with `overwrite=True` actually do that.