### PR TITLE
Fix to be more flexible with python3 versions

### DIFF
--- a/zygoat/components/frontend/eslint/resources/.eslintrc.js
+++ b/zygoat/components/frontend/eslint/resources/.eslintrc.js
@@ -1,23 +1,18 @@
 module.exports = {
-  parser: "babel-eslint",
+  parser: 'babel-eslint',
 
-  extends: [
-    "airbnb",
-    "plugin:jest/recommended",
-    "prettier",
-    "prettier/react"
-  ],
+  extends: ['airbnb', 'plugin:jest/recommended', 'prettier', 'prettier/react'],
 
-  plugins: ["react", "react-hooks", "prettier"],
+  plugins: ['react', 'react-hooks', 'prettier'],
 
   env: {
     browser: true,
-    jest: true
+    jest: true,
   },
 
   globals: {
     // React.js
-    React: "writable",
+    React: 'writable',
     // Jest
     describe: false,
     jest: false,
@@ -25,24 +20,24 @@ module.exports = {
 
   rules: {
     // next.js does not require importing React at the top of the components everytime
-    "react/react-in-jsx-scope": "off",
+    'react/react-in-jsx-scope': 'off',
 
     // We don't want `console` calls in our code because they are generally
     //   used for debugging.
-    "no-console": "error",
+    'no-console': 'error',
 
     // This rule makes string interpolation difficult because it makes you
     //   need explicit whitespace expressions.
-    "react/jsx-one-expression-per-line": "off",
+    'react/jsx-one-expression-per-line': 'off',
 
     // Generally, we want to make sure prop types are used in our components,
     //   but since we use the stores everywhere, it just ends up adding a lot
     //   of boilerplate, so we skip it for the stores only.
-    "react/prop-types": [
-      "error",
+    'react/prop-types': [
+      'error',
       {
-        ignore: ["stores"]
-      }
+        ignore: ['stores'],
+      },
     ],
 
     // There are many situations where libraries expect you to modify the
@@ -51,13 +46,13 @@ module.exports = {
 
     // We want to keep spacing consistent even for the children, which is not
     //   enabled by default, but should be.
-    "react/jsx-curly-spacing": [
-      "error",
+    'react/jsx-curly-spacing': [
+      'error',
       {
-        when: "never",
+        when: 'never',
         children: true,
-        allowMultiline: true
-      }
+        allowMultiline: true,
+      },
     ],
 
     // NextJS Link components want to contain an anchor tag without an href as
@@ -88,13 +83,13 @@ module.exports = {
   },
 
   settings: {
-    "import/resolver": {
-      "babel-module": {
+    'import/resolver': {
+      'babel-module': {
         alias: {
-          "@wui": "@bequestinc/wui",
-          "@@": "./"
-        }
-      }
-    }
-  }
+          '@wui': '@bequestinc/wui',
+          '@@': './',
+        },
+      },
+    },
+  },
 };

--- a/zygoat/components/resources/.pre-commit-config.yaml
+++ b/zygoat/components/resources/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: black
         args: [--config, backend/pyproject.toml]
-        language_version: python3.7
+        language_version: python3
   - repo: https://github.com/prettier/prettier
     rev: 2.0.2
     hooks:


### PR DESCRIPTION
@metlife-eliles and @laks12metlife ran into this when trying to install precommit hooks. They're on py3.8 and that caused precommit hooks to break. This'll fix things. Worked for me locally. 