### PR TITLE
Pass PORTUNUS_URL through NextJS config

### DIFF
--- a/zygoat/components/frontend/resources/zygoat.next.config.js
+++ b/zygoat/components/frontend/resources/zygoat.next.config.js
@@ -16,6 +16,7 @@ const config = {
   env: {
     PROD: prod,
     BACKEND_URL: prod ? process.env.BACKEND_URL : 'http://backend:3001',
+    PORTUNUS_URL: process.env.PORTUNUS_URL,
   },
 };
 


### PR DESCRIPTION
Adding this is to the next config is a little awkward, maybe this would be ideally added by the token component in `willing-zg`, but the way things are set up now makes that difficult to do cleanly. I think the simplest thing is to just add it here and there is no harm done if `PORTUNUS_URL` does not exist in the environment variables.