### PR TITLE
SETTINGS: allow components to update settings once installed

### DIFF
--- a/zygoat/components/backend/settings/resources/zygoat_settings.py
+++ b/zygoat/components/backend/settings/resources/zygoat_settings.py
@@ -1,0 +1,105 @@
+"""
+This settings file is generated and updated by Zygoat and should not be edited
+manually. Instead, update settings via this package's __init__.py.
+"""
+
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = None
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "backend.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "backend.wsgi.application"
+
+
+# Database
+# https://docs.djangoproject.com/en/3.0/ref/settings/#databases
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    }
+}
+
+
+# Password validation
+# https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+]
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/3.0/topics/i18n/
+
+LANGUAGE_CODE = "en-us"
+
+TIME_ZONE = "UTC"
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/3.0/howto/static-files/
+
+STATIC_URL = "/static/"

--- a/zygoat/components/backend/settings/secret_key.py
+++ b/zygoat/components/backend/settings/secret_key.py
@@ -1,4 +1,6 @@
+import base64
 import logging
+import os
 
 from zygoat.components import SettingsComponent
 
@@ -10,8 +12,8 @@ class SecretKey(SettingsComponent):
         red = self.parse()
         key_node = red.find("name", value="SECRET_KEY").parent
 
-        log.info("Retrieving default secret key")
-        default_key = key_node.value.to_python()
+        log.info("Generating default secret key")
+        default_key = base64.b64encode(os.urandom(32)).decode("utf-8")
 
         log.info("Relocating default secret key")
         key_node.value = f"prod_required_env('DJANGO_SECRET_KEY', default='{default_key}')"
@@ -19,12 +21,18 @@ class SecretKey(SettingsComponent):
         log.info("Dumping secret key node")
         self.dump(red)
 
+    def update(self):
+        red = self.parse()
+
+        log.info("Copying secret key value from previous settings")
+        key_node = red.find("name", value="SECRET_KEY").parent
+        key_node.value = self.parent.existing_secret_key
+
+        self.dump(red)
+
     @property
     def installed(self):
-        red = self.parse()
-        return (
-            "prod_required_env(" in red.find("name", value="SECRET_KEY").parent.value.dumps()
-        )
+        return bool(getattr(self.parent, "existing_secret_key", None))
 
 
 secret_key = SecretKey()

--- a/zygoat/components/backend/settings/settings_file.py
+++ b/zygoat/components/backend/settings/settings_file.py
@@ -1,0 +1,17 @@
+import os
+
+from zygoat.components import FileComponent, SettingsComponent
+from zygoat.constants import Projects
+
+from . import resources
+
+
+class SettingsFile(FileComponent):
+    filename = "zygoat_settings.py"
+    resource_pkg = resources
+    base_path = os.path.join(
+        Projects.BACKEND, Projects.BACKEND, SettingsComponent.DIRECTORY_NAME,
+    )
+
+
+settings_file = SettingsFile()

--- a/zygoat/components/base.py
+++ b/zygoat/components/base.py
@@ -40,7 +40,7 @@ class Component:
         self.parent = parent
 
         for component in sub_components:
-            component.parent = self.identifier
+            component.parent = self
             self.sub_components.append(component)
 
     @property
@@ -60,7 +60,7 @@ class Component:
         if self.parent is None:
             return self.name
 
-        return f"{self.parent}__{self.name}"
+        return f"{self.parent.identifier}__{self.name}"
 
     @property
     def styled_identifier(self):
@@ -181,4 +181,4 @@ class Component:
         self.config = Config()
 
         for component in self.sub_components:
-            component.parent = self.identifier
+            component.parent = self


### PR DESCRIPTION
Closes #85 

This builds the zygoat_settings.py file from scratch each time update is run instead of updating the existing file, which means that updates to settings components will show up on update, without needing to modify the `installed` property each time.

I'm not super happy with the way that this preserves the default secret key during updates (as an alternative we could just not care about this), but this was the best approach that I could think of.