### PR TITLE
SETTINGS: Set DEBUG flag correctly

### DIFF
--- a/zygoat/components/backend/settings/debug_config.py
+++ b/zygoat/components/backend/settings/debug_config.py
@@ -19,7 +19,7 @@ class DebugConfig(SettingsComponent):
         debug_node = red.find("name", value="DEBUG").parent
 
         log.info("Disabling debug in production")
-        debug_node.value = "not PRODUCTION"
+        debug_node.value = "False if PRODUCTION else env.bool('DJANGO_DEBUG', default=True)"
 
         log.info("Dumping debug configuration node")
         self.dump(red)


### PR DESCRIPTION
This is so that we are able to turn DEBUG flag to `False` on non-prod environments when needed.