### PR TITLE
SETTINGS: don't mark cookies as secure in debug mode

### DIFF
--- a/zygoat/components/backend/settings/cookies.py
+++ b/zygoat/components/backend/settings/cookies.py
@@ -22,8 +22,8 @@ class Cookies(SettingsComponent):
                 "SESSION_COOKIE_DOMAIN = SHARED_DOMAIN",
                 "SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'",
                 "SESSION_COOKIE_AGE = 3600  # One hour in seconds",
-                "SESSION_COOKIE_SECURE = True",
-                "CSRF_COOKIE_SECURE = True",
+                "SESSION_COOKIE_SECURE = not DEBUG",
+                "CSRF_COOKIE_SECURE = not DEBUG",
                 "\n",
             ]
         )


### PR DESCRIPTION
Since we use HTTP for local development, the browser won't respect secure cookies. The DEBUG flag seems like a good choice to me for determining this, but lmk if anyone disagrees.