### PR TITLE
Remove browsable api renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.2.3"
+version = "1.2.4"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/backend/settings/drf_camelize.py
+++ b/zygoat/components/backend/settings/drf_camelize.py
@@ -8,7 +8,6 @@ log = logging.getLogger()
 settings_string = """REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": (
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
-        "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",
     ),
     "DEFAULT_PARSER_CLASSES": (
         "djangorestframework_camel_case.parser.CamelCaseFormParser",
@@ -17,12 +16,17 @@ settings_string = """REST_FRAMEWORK = {
     ),
 }"""
 
+browsable_api_settings_string = """if DEBUG:
+    REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += (
+        "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",
+    )"""
+
 
 class DRF_Camelize(SettingsComponent):
     def create(self):
         red = self.parse()
 
-        red.extend(["\n", settings_string])
+        red.extend(["\n", settings_string, "\n", browsable_api_settings_string])
 
         log.info("Dumping DRF camelize configuration")
         self.dump(red)


### PR DESCRIPTION
I noticed while going through sentry issues that drf includes some browsable api routes by default. Some of them are not configured properly and result in server errors. I don't think this is a serious problem, but I also don't think we have any use for them in production so we may as well turn them off for now.

~~While making this change I noticed a couple of other issues with zygoat and included those fixes here, too.~~ Edit: turns out I was not up to date with the latest master, whoops.