### PR TITLE
COMPONENTS: update pre-commit black version

### DIFF
--- a/zygoat/components/resources/.pre-commit-config.yaml
+++ b/zygoat/components/resources/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: bandit
         args: [--recursive, -ll, -iii, -c, backend/tests/.banditrc]
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
         args: [--config, backend/pyproject.toml]


### PR DESCRIPTION
This update is needed for pre-commit with the new black version release that is being installed by requirements.py.

Per https://github.com/MetLifeLegalPlans/members/pull/626, we may want to eventually pin the version of flake8-black