### PR TITLE
Use new gitignore API endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.4.0"
+version = "1.4.1"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/backend/gitignore.py
+++ b/zygoat/components/backend/gitignore.py
@@ -13,7 +13,7 @@ class GitIgnore(Component):
     def create(self):
         with open(file_name, "a") as f:
             log.info("Retrieving python gitignore info")
-            res = requests.get("https://gitignore.io/api/python")
+            res = requests.get("https://www.toptal.com/developers/gitignore/api/python")
             res.raise_for_status()
 
             f.write(res.text)

--- a/zygoat/components/frontend/gitignore.py
+++ b/zygoat/components/frontend/gitignore.py
@@ -13,7 +13,7 @@ class GitIgnore(Component):
     def create(self):
         with open(file_name, "a") as f:
             log.info("Retrieving node gitignore info")
-            res = requests.get("https://gitignore.io/api/node")
+            res = requests.get("https://www.toptal.com/developers/gitignore/api/node")
             res.raise_for_status()
 
             f.write(res.text + "\n")


### PR DESCRIPTION
Apparently `gitignore.io` has been moved to a new location