### PR TITLE
FRONTEND: add in missing dev dependencies for jest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.7.1"
+version = "1.7.2"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/frontend/dependencies/__init__.py
+++ b/zygoat/components/frontend/dependencies/__init__.py
@@ -15,7 +15,14 @@ log = logging.getLogger()
 
 class Dependencies(Component):
     dependencies = ["prop-types", "axios", "next-compose-plugins", "next-svgr", "next-images"]
-    dev_dependencies = ["jest", "react-axe", "@testing-library/dom", "@testing-library/react"]
+    dev_dependencies = [
+        "jest",
+        "react-axe",
+        "@testing-library/dom",
+        "@testing-library/react",
+        "@testing-library/jest-dom",
+        "css-mediaquery",
+    ]
 
     def create(self):
         with use_dir(Projects.FRONTEND):


### PR DESCRIPTION
adds in dependencies that were missing from #123. noticed on https://github.com/MetLifeLegalPlans/document-generation/pull/24.

tested with the docgen repo.