### PR TITLE
Add redis cache to the standard layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.5.0"
+version = "1.6.0"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/backend/cache.py
+++ b/zygoat/components/backend/cache.py
@@ -42,8 +42,8 @@ class Cache(Component):
 
         backend_depends = config["services"][Projects.BACKEND].get("depends_on", [])
 
-        if Projects.CACHE in config["services"][Projects.BACKEND].get("depends_on", []):
-            del backend_depends[backend_depends.index(Projects.CACHE)]
+        if Projects.CACHE in backend_depends:
+            backend_depends.remove(Projects.CACHE)
 
         config["services"][Projects.BACKEND]["depends_on"] = backend_depends
 

--- a/zygoat/components/backend/resources/docker-compose.cache.yml
+++ b/zygoat/components/backend/resources/docker-compose.cache.yml
@@ -1,0 +1,4 @@
+cache:
+    image: redis
+    ports:
+        - 6379:6379

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -16,6 +16,7 @@ phase_function_names = [
 project_dir_names = [
     "backend",
     "frontend",
+    "cache",
 ]
 
 Phases = Box([(t.upper(), t) for t in phase_function_names])


### PR DESCRIPTION
There'll be a corresponding PR in `zygoat-django` to add some cache integration, as well as fixing the documentation since there's no more manual intervention required in the settings file.