### PR TITLE
Add prettierignore file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.6.0"
+version = "1.6.1"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/frontend/prettier/__init__.py
+++ b/zygoat/components/frontend/prettier/__init__.py
@@ -9,6 +9,7 @@ from zygoat.utils.files import use_dir
 from .prettierrc import prettierrc
 from .be_pretty import be_pretty
 from .pretty_quick import pretty_quick
+from .prettierignore import prettierignore
 
 log = logging.getLogger()
 
@@ -29,4 +30,4 @@ class Prettier(Component):
                 return "prettier" in json.load(f).get("devDependencies", {})
 
 
-prettier = Prettier(sub_components=[prettierrc, be_pretty, pretty_quick])
+prettier = Prettier(sub_components=[prettierrc, be_pretty, pretty_quick, prettierignore])

--- a/zygoat/components/frontend/prettier/prettierignore.py
+++ b/zygoat/components/frontend/prettier/prettierignore.py
@@ -1,0 +1,11 @@
+from zygoat.components import FileComponent
+
+from . import resources
+
+
+class PrettierIgnore(FileComponent):
+    filename = ".prettierignore"
+    resource_pkg = resources
+
+
+prettierignore = PrettierIgnore()

--- a/zygoat/components/frontend/prettier/resources/.prettierignore
+++ b/zygoat/components/frontend/prettier/resources/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore all html files in the backend dir as they'll be django templates.
+backend/**/*.html


### PR DESCRIPTION
found that prettier mangled the template files i was working with on https://github.com/MetLifeLegalPlans/document-generation/pull/36 to where they wouldn't work. figured this was pretty safe to exclude wholesale but lmk if there's a good reason why it should be more specific.

tested on docgen repo.