### PR TITLE
BACKEND: Don't add packages with extras multiple times to requirements file

### DIFF
--- a/zygoat/utils/backend.py
+++ b/zygoat/utils/backend.py
@@ -23,7 +23,10 @@ def packages_to_map(arr):
             if "git://" in package_line:
                 result[package_line] = package_line
             continue
-        package = package_line.split("=")[0]
+        if "[" in package_line:
+            package = package_line.split("[")[0]
+        else:
+            package = package_line.split("=")[0]
         result[package] = package_line
 
     return result


### PR DESCRIPTION
closes #147 

It was parsing as `uvicorn[standard]` and then the `uvicorn` package was also being added causing it to appear twice in the requirements file. 