### PR TITLE
FRONTEND: Enable production source maps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.9.4"
+version = "1.10.0"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/frontend/resources/zygoat.next.config.js
+++ b/zygoat/components/frontend/resources/zygoat.next.config.js
@@ -72,6 +72,7 @@ const config = {
       headers: headers,
     },
   ],
+  productionBrowserSourceMaps: true,
 };
 
 const withImagesConfig = {


### PR DESCRIPTION
Given that the JS bundle we send to the client can already be trivially un-minified by anyone that cares to do so, I don't know if we get much benefit from juggling more credentials and configuration during CI/CD to upload them to Sentry.