### PR TITLE
Less ESBuild, move to Webpack5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.10.0"
+version = "1.11.0"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/frontend/__init__.py
+++ b/zygoat/components/frontend/__init__.py
@@ -33,6 +33,9 @@ class Frontend(Component):
         log.info("Deleting default _app.js file (added in create-next-app v9.5.5)")
         os.remove(os.path.join(Projects.FRONTEND, "pages", "_app.js"))
 
+        log.info("Deleting default next.config.js (added in create-next-app v11)")
+        os.remove(os.path.join(Projects.FRONTEND, "next.config.js"))
+
         log.info("Deleting the default api directory")
         shutil.rmtree(os.path.join(Projects.FRONTEND, "pages", "api"))
 

--- a/zygoat/components/frontend/dependencies/__init__.py
+++ b/zygoat/components/frontend/dependencies/__init__.py
@@ -29,7 +29,6 @@ class Dependencies(Component):
         "@testing-library/react",
         "@testing-library/jest-dom",
         "css-mediaquery",
-        "esbuild-loader",
     ]
 
     def create(self):

--- a/zygoat/components/frontend/resources/zygoat.next.config.js
+++ b/zygoat/components/frontend/resources/zygoat.next.config.js
@@ -2,8 +2,6 @@
 // be edited manually. To extend or overwrite these settings, edit
 // next.config.js
 
-const { ESBuildMinifyPlugin } = require('esbuild-loader');
-
 const withSvgr = require('next-svgr');
 const withImages = require('next-images');
 
@@ -18,25 +16,8 @@ const headers = [
   { key: 'X-XSS-Protection', value: '1; mode=block' },
 ];
 
-function useEsbuildMinify(config, options) {
-  const terserIndex = config.optimization.minimizer.findIndex(
-    minimizer => minimizer.constructor.name === 'TerserPlugin',
-  );
-  if (terserIndex > -1) {
-    config.optimization.minimizer.splice(terserIndex, 1, new ESBuildMinifyPlugin(options));
-  }
-}
-
-function useEsbuildLoader(config, options) {
-  const jsLoader = config.module.rules.find(rule => rule.test && rule.test.test('.js'));
-
-  if (jsLoader) {
-    jsLoader.use.loader = 'esbuild-loader';
-    jsLoader.use.options = options;
-  }
-}
-
 const config = {
+  webpack5: true,
   webpack: (webpackConfig, { webpack }) => {
     webpackConfig.resolve.alias['@@'] = __dirname;
     webpackConfig.resolve.alias['@wui'] = '@bequestinc/wui';
@@ -46,13 +27,6 @@ const config = {
         React: 'react',
       }),
     );
-
-    useEsbuildMinify(webpackConfig);
-
-    useEsbuildLoader(webpackConfig, {
-      loader: 'jsx',
-      target: 'es2015',
-    });
 
     return webpackConfig;
   },


### PR DESCRIPTION
NextJS 11 is out (rejoice!) and it fixes a lot of issues. It also breaks our ESBuild configuration, so we lose that performance increase, but hot reloading is now significantly less flaky.