### PR TITLE
SECURITY: remove powered-by header from http responses

### DIFF
--- a/zygoat/components/frontend/resources/zygoat.next.config.js
+++ b/zygoat/components/frontend/resources/zygoat.next.config.js
@@ -47,6 +47,7 @@ const config = {
     },
   ],
   productionBrowserSourceMaps: true,
+  poweredByHeader: false,
 };
 
 const withImagesConfig = {


### PR DESCRIPTION
The existence of this header is deemed harmful by the Primeon testing team.