### PR TITLE
Pull docker images before running them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "1.14.0"
+version = "1.14.1"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/utils/shell.py
+++ b/zygoat/utils/shell.py
@@ -2,6 +2,8 @@ import shlex
 import subprocess
 import os
 
+pulled_images = set()
+
 
 def run(cmd, *args, **kwargs):
     """
@@ -19,6 +21,10 @@ def run(cmd, *args, **kwargs):
 
 
 def docker_run(cmd, image, vol, chown=True, *args, **kwargs):
+    if image not in pulled_images:
+        run(["docker", "pull", image])
+        pulled_images.add(image)
+
     vol_directory = os.path.join(os.getcwd(), vol)
     prelude = ["docker", "run", "-v", f"{vol_directory}:/data", "-w", "/data", image]
     ret = run(prelude + cmd, *args, **kwargs)


### PR DESCRIPTION
Closes #166 
Closes #165 

Both of these were caused by you having an outdated `node:latest` image on your local machine.