### PR TITLE
add the emotion styled dependency

### DIFF
--- a/zygoat/components/frontend/dependencies/mui.py
+++ b/zygoat/components/frontend/dependencies/mui.py
@@ -36,6 +36,7 @@ class Mui(Component):
                 "@emotion/cache",
                 "@emotion/react",
                 "@emotion/server",
+                "@emotion/styled",
             ],
             Images.NODE,
             Projects.FRONTEND,


### PR DESCRIPTION
with trying to compile the newly created sponsors app there was an error saying we needed the `@emotion/styled` dependency. 
When adding this dependency everything worked as normal.

Unsure to why this is as currently in epzg app we don't have this dependency and it compiles fine. Will try to investigate this further but I do believe this will be a needed dependency. 

