### PR TITLE
Use yarn.lock during local builds as well

### DIFF
--- a/zygoat/components/frontend/resources/Dockerfile.local
+++ b/zygoat/components/frontend/resources/Dockerfile.local
@@ -3,6 +3,7 @@ FROM node:latest
 RUN mkdir /code
 WORKDIR /code
 ADD package.json /code/
+ADD yarn.lock /code/
 RUN yarn install
 
 CMD yarn dev -p 3000


### PR DESCRIPTION
Discovered when a misbehaving package caused issues on docgen prod but not local.