### PR TITLE
DOCKER: update containers to copy/cache dependencies

### DIFF
--- a/zygoat/components/backend/resources/Dockerfile
+++ b/zygoat/components/backend/resources/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /code
 WORKDIR /code
 
 COPY poetry.lock pyproject.toml /code/
-RUN poetry install
+RUN poetry install --no-dev
 
 COPY . .
 

--- a/zygoat/components/backend/resources/Dockerfile
+++ b/zygoat/components/backend/resources/Dockerfile
@@ -5,7 +5,9 @@ RUN pip install --upgrade pip poetry
 RUN mkdir /code
 WORKDIR /code
 
-COPY . .
+COPY poetry.lock pyproject.toml /code/
 RUN poetry install
+
+COPY . .
 
 CMD poetry run ./manage.py wait_for_db && poetry run ./manage.py migrate && poetry run ./manage.py createcachetable && poetry run gunicorn -w 4 -b 0.0.0.0:3000 backend.asgi -k zygoat_django.uvicorn_worker.ZygoatUvicornWorker

--- a/zygoat/components/backend/resources/Dockerfile.local
+++ b/zygoat/components/backend/resources/Dockerfile.local
@@ -5,8 +5,9 @@ RUN pip install --upgrade pip poetry
 RUN mkdir /code
 WORKDIR /code
 
-ADD pyproject.toml /code/
-ADD poetry.lock /code/
+COPY poetry.lock pyproject.toml /code/
 RUN poetry install
+
+COPY . .
 
 CMD poetry run ./manage.py wait_for_db && poetry run ./manage.py migrate && poetry run ./manage.py createcachetable && poetry run uvicorn --host 0.0.0.0 --port 3001 --reload backend.asgi:application

--- a/zygoat/components/backend/resources/Dockerfile.local
+++ b/zygoat/components/backend/resources/Dockerfile.local
@@ -8,6 +8,4 @@ WORKDIR /code
 COPY poetry.lock pyproject.toml /code/
 RUN poetry install
 
-COPY . .
-
 CMD poetry run ./manage.py wait_for_db && poetry run ./manage.py migrate && poetry run ./manage.py createcachetable && poetry run uvicorn --host 0.0.0.0 --port 3001 --reload backend.asgi:application

--- a/zygoat/components/frontend/resources/Dockerfile.local
+++ b/zygoat/components/frontend/resources/Dockerfile.local
@@ -6,6 +6,4 @@ WORKDIR /code
 COPY package.json yarn.lock /code/
 RUN yarn install
 
-COPY . .
-
 CMD yarn dev -p 3000

--- a/zygoat/components/frontend/resources/Dockerfile.local
+++ b/zygoat/components/frontend/resources/Dockerfile.local
@@ -2,8 +2,10 @@ FROM node:latest
 
 RUN mkdir /code
 WORKDIR /code
-ADD package.json /code/
-ADD yarn.lock /code/
+
+COPY package.json yarn.lock /code/
 RUN yarn install
+
+COPY . .
 
 CMD yarn dev -p 3000


### PR DESCRIPTION
closes #173 

on top of the dependency caching, I went ahead and changed a couple of places where we were using ADD to copy files over to use COPY instead. since all we're doing is copying local files over


I also added `COPY . .`  in each of the .local files. do we not need that?