### PR TITLE
Make better use of the config file, add safeguards

### DIFF
--- a/zygoat/cli.py
+++ b/zygoat/cli.py
@@ -81,6 +81,7 @@ def init(project_name):
     _name_project(project_name)
 
     log.info(f"Initialized {config_file_name}")
+    log.info(str(Config().to_dict()))
 
 
 @cli.command(help="Creates a new settings file and all components")

--- a/zygoat/components/backend/__init__.py
+++ b/zygoat/components/backend/__init__.py
@@ -4,7 +4,7 @@ import shutil
 
 from .. import Component
 from zygoat.utils.shell import multi_docker_run
-from zygoat.constants import Projects, Images
+from zygoat.constants import Projects
 
 from .dockerfile import dockerfile
 from .settings import settings
@@ -36,7 +36,7 @@ class Backend(Component):
                     Projects.BACKEND,
                 ],
             ],
-            Images.PYTHON,
+            self.docker_image("PYTHON"),
             ".",
         )
 
@@ -51,7 +51,7 @@ class Backend(Component):
                 ],
                 ["poetry", "init", "-n", "--name", "backend"],
             ],
-            Images.PYTHON,
+            self.docker_image("PYTHON"),
             Projects.BACKEND,
         )
 

--- a/zygoat/components/backend/__init__.py
+++ b/zygoat/components/backend/__init__.py
@@ -4,7 +4,7 @@ import shutil
 
 from .. import Component
 from zygoat.utils.shell import multi_docker_run
-from zygoat.constants import Projects
+from zygoat.constants import Projects, Images
 
 from .dockerfile import dockerfile
 from .settings import settings
@@ -36,7 +36,7 @@ class Backend(Component):
                     Projects.BACKEND,
                 ],
             ],
-            self.docker_image("PYTHON"),
+            self.docker_image(Images.PYTHON),
             ".",
         )
 
@@ -51,7 +51,7 @@ class Backend(Component):
                 ],
                 ["poetry", "init", "-n", "--name", "backend"],
             ],
-            self.docker_image("PYTHON"),
+            self.docker_image(Images.PYTHON),
             Projects.BACKEND,
         )
 

--- a/zygoat/components/backend/reformat.py
+++ b/zygoat/components/backend/reformat.py
@@ -1,7 +1,7 @@
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Phases, Projects, Images
+from zygoat.constants import Phases, Projects
 from zygoat.utils.shell import multi_docker_run
 
 log = logging.getLogger()
@@ -10,7 +10,9 @@ log = logging.getLogger()
 class Reformat(Component):
     def create(self):
         multi_docker_run(
-            [["pip", "install", "black"], ["black", "."]], Images.PYTHON, Projects.BACKEND
+            [["pip", "install", "black"], ["black", "."]],
+            self.docker_image("PYTHON"),
+            Projects.BACKEND,
         )
 
     def update(self):

--- a/zygoat/components/backend/reformat.py
+++ b/zygoat/components/backend/reformat.py
@@ -1,7 +1,7 @@
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Phases, Projects
+from zygoat.constants import Phases, Projects, Images
 from zygoat.utils.shell import multi_docker_run
 
 log = logging.getLogger()
@@ -11,7 +11,7 @@ class Reformat(Component):
     def create(self):
         multi_docker_run(
             [["pip", "install", "black"], ["black", "."]],
-            self.docker_image("PYTHON"),
+            self.docker_image(Images.PYTHON),
             Projects.BACKEND,
         )
 

--- a/zygoat/components/base.py
+++ b/zygoat/components/base.py
@@ -5,7 +5,7 @@ from click import style
 
 from zygoat.utils.files import repository_root
 from zygoat.config import Config
-from zygoat.constants import Phases
+from zygoat.constants import Phases, ConfigDefaults
 
 log = logging.getLogger()
 
@@ -92,6 +92,15 @@ class Component:
         Convenience wrapper for easier reading
         """
         return not self.exclude
+
+    def docker_image(self, identifier):
+        """
+        Checks the config file for a docker image and returns the default value if not specified
+        """
+        try:
+            return self.config.images[identifier]
+        except AttributeError:
+            return ConfigDefaults.images[identifier]
 
     def call_phase(self, phase, force_create=False):
         """

--- a/zygoat/components/frontend/__init__.py
+++ b/zygoat/components/frontend/__init__.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -23,7 +23,9 @@ class Frontend(Component):
     def create(self):
         log.info("Running create-next-app")
         docker_run(
-            ["yarn", "create", "next-app", Projects.FRONTEND], self.docker_image("NODE"), "."
+            ["yarn", "create", "next-app", Projects.FRONTEND],
+            self.docker_image(Images.NODE),
+            ".",
         )
 
         log.info("Emptying a poorly formatted index.js file")
@@ -52,7 +54,7 @@ class Reformat(Component):
         log.info("Formatting package.json with prettier")
         with use_dir(Projects.FRONTEND):
             docker_run(
-                ["yarn", "prettier", "-w", "package.json"], self.docker_image("NODE"), "."
+                ["yarn", "prettier", "-w", "package.json"], self.docker_image(Images.NODE), "."
             )
 
     def update(self):

--- a/zygoat/components/frontend/__init__.py
+++ b/zygoat/components/frontend/__init__.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -22,7 +22,9 @@ log = logging.getLogger()
 class Frontend(Component):
     def create(self):
         log.info("Running create-next-app")
-        docker_run(["yarn", "create", "next-app", Projects.FRONTEND], Images.NODE, ".")
+        docker_run(
+            ["yarn", "create", "next-app", Projects.FRONTEND], self.docker_image("NODE"), "."
+        )
 
         log.info("Emptying a poorly formatted index.js file")
         open(os.path.join(Projects.FRONTEND, "pages", "index.js"), "w").close()
@@ -49,7 +51,9 @@ class Reformat(Component):
     def create(self):
         log.info("Formatting package.json with prettier")
         with use_dir(Projects.FRONTEND):
-            docker_run(["yarn", "prettier", "-w", "package.json"], Images.NODE, ".")
+            docker_run(
+                ["yarn", "prettier", "-w", "package.json"], self.docker_image("NODE"), "."
+            )
 
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)

--- a/zygoat/components/frontend/dependencies/__init__.py
+++ b/zygoat/components/frontend/dependencies/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.components import Component
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
@@ -33,11 +33,15 @@ class Dependencies(Component):
 
     def create(self):
         log.info("Installing frontend production dependencies")
-        docker_run(["yarn", "add", *self.dependencies], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "add", *self.dependencies], self.docker_image("NODE"), Projects.FRONTEND
+        )
 
         log.info("Installing frontend dev dependencies")
         docker_run(
-            ["yarn", "add", "--dev", *self.dev_dependencies], Images.NODE, Projects.FRONTEND
+            ["yarn", "add", "--dev", *self.dev_dependencies],
+            self.docker_image("NODE"),
+            Projects.FRONTEND,
         )
 
         with use_dir(Projects.FRONTEND):
@@ -54,7 +58,7 @@ class Dependencies(Component):
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)
         log.info("Upgrading frontend dependencies")
-        docker_run(["yarn", "upgrade"], Images.NODE, Projects.FRONTEND)
+        docker_run(["yarn", "upgrade"], self.docker_image("NODE"), Projects.FRONTEND)
 
     @property
     def installed(self):

--- a/zygoat/components/frontend/dependencies/__init__.py
+++ b/zygoat/components/frontend/dependencies/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.components import Component
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
@@ -34,13 +34,15 @@ class Dependencies(Component):
     def create(self):
         log.info("Installing frontend production dependencies")
         docker_run(
-            ["yarn", "add", *self.dependencies], self.docker_image("NODE"), Projects.FRONTEND
+            ["yarn", "add", *self.dependencies],
+            self.docker_image(Images.NODE),
+            Projects.FRONTEND,
         )
 
         log.info("Installing frontend dev dependencies")
         docker_run(
             ["yarn", "add", "--dev", *self.dev_dependencies],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 
@@ -58,7 +60,7 @@ class Dependencies(Component):
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)
         log.info("Upgrading frontend dependencies")
-        docker_run(["yarn", "upgrade"], self.docker_image("NODE"), Projects.FRONTEND)
+        docker_run(["yarn", "upgrade"], self.docker_image(Images.NODE), Projects.FRONTEND)
 
     @property
     def installed(self):

--- a/zygoat/components/frontend/dependencies/mui.py
+++ b/zygoat/components/frontend/dependencies/mui.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from zygoat.components import Component, FileComponent
-from zygoat.constants import Projects
+from zygoat.constants import Projects, Images
 from zygoat.utils.shell import docker_run
 
 from . import resources
@@ -38,7 +38,7 @@ class Mui(Component):
                 "@emotion/server",
                 "@emotion/styled",
             ],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 

--- a/zygoat/components/frontend/dependencies/mui.py
+++ b/zygoat/components/frontend/dependencies/mui.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from zygoat.components import Component, FileComponent
-from zygoat.constants import Projects, Images
+from zygoat.constants import Projects
 from zygoat.utils.shell import docker_run
 
 from . import resources
@@ -38,7 +38,7 @@ class Mui(Component):
                 "@emotion/server",
                 "@emotion/styled",
             ],
-            Images.NODE,
+            self.docker_image("NODE"),
             Projects.FRONTEND,
         )
 

--- a/zygoat/components/frontend/eslint/__init__.py
+++ b/zygoat/components/frontend/eslint/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.components import Component
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
@@ -27,21 +27,21 @@ class Eslint(Component):
         log.info("Installing eslint dev dependencies to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.dependencies],
-            Images.NODE,
+            self.docker_image("NODE"),
             Projects.FRONTEND,
         )
 
         log.info("Installing eslint plugins to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.plugins],
-            Images.NODE,
+            self.docker_image("NODE"),
             Projects.FRONTEND,
         )
 
         log.info("Installing eslint configs to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.configs],
-            Images.NODE,
+            self.docker_image("NODE"),
             Projects.FRONTEND,
         )
 

--- a/zygoat/components/frontend/eslint/__init__.py
+++ b/zygoat/components/frontend/eslint/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.components import Component
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
@@ -27,21 +27,21 @@ class Eslint(Component):
         log.info("Installing eslint dev dependencies to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.dependencies],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 
         log.info("Installing eslint plugins to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.plugins],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 
         log.info("Installing eslint configs to frontend")
         docker_run(
             ["yarn", "add", "--dev", *self.configs],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 

--- a/zygoat/components/frontend/prettier/__init__.py
+++ b/zygoat/components/frontend/prettier/__init__.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -18,7 +18,9 @@ class Prettier(Component):
     def create(self):
         log.info("Installing prettier dev dependency into the frontend project")
         docker_run(
-            ["yarn", "add", "--dev", "prettier"], self.docker_image("NODE"), Projects.FRONTEND
+            ["yarn", "add", "--dev", "prettier"],
+            self.docker_image(Images.NODE),
+            Projects.FRONTEND,
         )
 
     def update(self):

--- a/zygoat/components/frontend/prettier/__init__.py
+++ b/zygoat/components/frontend/prettier/__init__.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -17,7 +17,9 @@ log = logging.getLogger()
 class Prettier(Component):
     def create(self):
         log.info("Installing prettier dev dependency into the frontend project")
-        docker_run(["yarn", "add", "--dev", "prettier"], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "add", "--dev", "prettier"], self.docker_image("NODE"), Projects.FRONTEND
+        )
 
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)

--- a/zygoat/components/frontend/prettier/be_pretty.py
+++ b/zygoat/components/frontend/prettier/be_pretty.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -12,13 +12,25 @@ log = logging.getLogger()
 class BePretty(Component):
     def create(self):
         log.info("Installing be-pretty into frontend project")
-        docker_run(["yarn", "add", "--dev", "be-pretty@0.9.5"], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "add", "--dev", "be-pretty@0.9.5"],
+            self.docker_image("NODE"),
+            Projects.FRONTEND,
+        )
 
         log.info("Configuring be-pretty to use the correct RC file")
-        docker_run(["yarn", "run", "be-pretty", "setDefault"], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "run", "be-pretty", "setDefault"],
+            self.docker_image("NODE"),
+            Projects.FRONTEND,
+        )
 
         log.info("Formatting project with prettier")
-        docker_run(["yarn", "run", "be-pretty", "formatAll"], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "run", "be-pretty", "formatAll"],
+            self.docker_image("NODE"),
+            Projects.FRONTEND,
+        )
 
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)

--- a/zygoat/components/frontend/prettier/be_pretty.py
+++ b/zygoat/components/frontend/prettier/be_pretty.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -14,21 +14,21 @@ class BePretty(Component):
         log.info("Installing be-pretty into frontend project")
         docker_run(
             ["yarn", "add", "--dev", "be-pretty@0.9.5"],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 
         log.info("Configuring be-pretty to use the correct RC file")
         docker_run(
             ["yarn", "run", "be-pretty", "setDefault"],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 
         log.info("Formatting project with prettier")
         docker_run(
             ["yarn", "run", "be-pretty", "formatAll"],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 

--- a/zygoat/components/frontend/prettier/pretty_quick.py
+++ b/zygoat/components/frontend/prettier/pretty_quick.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases, Images
+from zygoat.constants import Projects, Phases
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -12,7 +12,11 @@ log = logging.getLogger()
 class PrettyQuick(Component):
     def create(self):
         log.info("Installing pretty-quick into frontend project")
-        docker_run(["yarn", "add", "--dev", "pretty-quick"], Images.NODE, Projects.FRONTEND)
+        docker_run(
+            ["yarn", "add", "--dev", "pretty-quick"],
+            self.docker_image("NODE"),
+            Projects.FRONTEND,
+        )
 
         with use_dir(Projects.FRONTEND):
             log.info("Adding pretty-quick lint command")

--- a/zygoat/components/frontend/prettier/pretty_quick.py
+++ b/zygoat/components/frontend/prettier/pretty_quick.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from zygoat.components import Component
-from zygoat.constants import Projects, Phases
+from zygoat.constants import Projects, Phases, Images
 from zygoat.utils.shell import docker_run
 from zygoat.utils.files import use_dir
 
@@ -14,7 +14,7 @@ class PrettyQuick(Component):
         log.info("Installing pretty-quick into frontend project")
         docker_run(
             ["yarn", "add", "--dev", "pretty-quick"],
-            self.docker_image("NODE"),
+            self.docker_image(Images.NODE),
             Projects.FRONTEND,
         )
 

--- a/zygoat/config.py
+++ b/zygoat/config.py
@@ -10,7 +10,7 @@ import logging
 from semver import VersionInfo
 
 from .utils.files import find_nearest
-from .constants import config_file_name, __version__
+from .constants import config_file_name, __version__, ConfigDefaults
 
 
 yaml = YAML(typ="safe")
@@ -46,6 +46,7 @@ class Config(object):
             sys.exit(1)
 
         data = {"version": __version__}
+        data.update(ConfigDefaults)
         data.update(initial_data)
 
         Config.dump(Box(data))
@@ -88,9 +89,12 @@ class Config(object):
         loaded = VersionInfo.parse(conf_version)
 
         if current < loaded:
-            raise EnvironmentError(
-                f"Current version of Zygoat ({current}) is older than project version ({loaded}), exiting"
+            log.critical(
+                "Current version of Zygoat ({}) is older than project version ({}), exiting".format(
+                    style(current, bold=True, fg="red"), style(loaded, bold=True, fg="red")
+                )
             )
+            sys.exit(1)
 
         log.debug(f"Bumping project version flag from {loaded} to {current}")
         conf.version = __version__

--- a/zygoat/config.py
+++ b/zygoat/config.py
@@ -91,3 +91,7 @@ class Config(object):
             raise EnvironmentError(
                 f"Current version of Zygoat ({current}) is older than project version ({loaded}), exiting"
             )
+
+        log.debug(f"Bumping project version flag from {loaded} to {current}")
+        conf.version = __version__
+        cls.dump(conf)

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -23,6 +23,8 @@ Phases = Box([(t.upper(), t) for t in phase_function_names])
 Projects = Box([(t.upper(), t) for t in project_dir_names])
 Images = Box({"NODE": "node:latest", "PYTHON": "python:latest"})
 
+ConfigDefaults = Box({"images": {"NODE": "node:latest", "PYTHON": "python:latest"}})
+
 FrontendUtils = os.path.join(Projects.FRONTEND, "zg_utils")
 
 __version__ = version("zygoat")

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -21,7 +21,7 @@ project_dir_names = [
 
 Phases = Box([(t.upper(), t) for t in phase_function_names])
 Projects = Box([(t.upper(), t) for t in project_dir_names])
-Images = Box({"NODE": "node:latest", "PYTHON": "python:latest"})
+Images = Box({"NODE": "NODE", "PYTHON": "PYTHON"})
 
 ConfigDefaults = Box({"images": {"NODE": "node:latest", "PYTHON": "python:latest"}})
 

--- a/zygoat/utils/backend.py
+++ b/zygoat/utils/backend.py
@@ -1,6 +1,7 @@
 from .shell import multi_docker_run
 from .files import repository_root
-from zygoat.constants import Images, Projects
+from zygoat.constants import Projects, ConfigDefaults
+from zygoat.config import Config
 
 
 def install_dependencies(*args, dev=False):
@@ -13,6 +14,12 @@ def install_dependencies(*args, dev=False):
     :param dev: Specifies if this is a development or production dependency
     :type dev: bool, optional
     """
+
+    try:
+        image = Config().images.PYTHON
+    except AttributeError:
+        image = ConfigDefaults.images.PYTHON
+
     with repository_root():
         add_command = ["poetry", "add"]
         if dev:
@@ -29,6 +36,6 @@ def install_dependencies(*args, dev=False):
                 ],
                 add_command + list(args),  # args is a tuple and those can't be concatenated
             ],
-            Images.PYTHON,
+            image,
             Projects.BACKEND,
         )


### PR DESCRIPTION
This was groundwork for a larger set of changes to Zygoat to improve UX, but I got sidetracked other things and can't remember where I was going with this.

Either way, this adds a few features:
 - `zg update` can no longer be run if the version of `zygoat` the user is running is older than the project version
 - The user can specify in their `zygoat_settings.yml` file the base images used for project creation, if they need to use an older version of `node` or `python`
 - Default configuration values are now stored inside of the constants file to make expanding on the configuration better

The documentation is still out of date and incomplete and I'll be working on that the next time I have the bandwidth to sit down and write that up.