### PR TITLE
INIT: run create-app non-interactively

### DIFF
--- a/zygoat/components/frontend/__init__.py
+++ b/zygoat/components/frontend/__init__.py
@@ -22,8 +22,16 @@ log = logging.getLogger()
 class Frontend(Component):
     def create(self):
         log.info("Running create-next-app")
+        non_interactive_args = [
+            "--js",
+            "--eslint",
+            "--no-tailwind",
+            "--no-src-dir",
+            "--no-experimental-app",
+            "--import-alias '@/*'",
+        ]
         docker_run(
-            ["yarn", "create", "next-app", Projects.FRONTEND],
+            ["yarn", "create", "next-app", Projects.FRONTEND, *non_interactive_args],
             self.docker_image(Images.NODE),
             ".",
         )
@@ -39,6 +47,9 @@ class Frontend(Component):
 
         log.info("Deleting the default api directory")
         shutil.rmtree(os.path.join(Projects.FRONTEND, "pages", "api"))
+
+        log.info("Deleting default _document.js")
+        os.remove(os.path.join(Projects.FRONTEND, "pages", "_document.js"))
 
     def delete(self):
         log.warning(f"Deleting the {Projects.FRONTEND} project")


### PR DESCRIPTION
The automated test that checks output was failing because of interactive prompts during the `create next-app` command. This PR adds flags so the command is run non-interactively. This also adds a command to remove another file post-creation that trips up the linter.